### PR TITLE
fix: correct change_parames_faild to change_params_failed in error_message.py

### DIFF
--- a/error_message.py
+++ b/error_message.py
@@ -172,7 +172,7 @@ class MessageEnum(Enum):
     test_sql_reply_sql_field=100160,'依赖数据库必须有字段'
     test_sql_connect_sql_error=100161,'链接数据库出现问题'
     test_sql_query_error=100162,'查询数据库出现问题'
-    change_parames_faild=100163,'转化请求参数失败'
+    change_params_failed=100163,'转化请求参数失败'
     test_case_run_error=100164,'测试用例测试失败,请检查用例！'
     test_case_run_pass=100165,'测试用例执行通过'
     test_case_run_fail=100166,'测试用例测试失败,请检查用例！'


### PR DESCRIPTION
## Summary

Fix typo in error message variable name in `error_message.py` line 175:

- `change_parames_faild` → `change_params_failed`
- Two typos in one variable name: `parames` → `params`, `faild` → `failed`

Error code 100163: `'转化请求参数失败'` (failed to transform request parameters)

## Changes

- 1 file changed, 1 line modified
- Only the typo fix, no other changes

## Testing

- Local syntax check: `python3 -m py_compile error_message.py` ✅

---

PR is mergeable (1 commit, 1 file change). Let me know if any adjustments needed!